### PR TITLE
Allow verbose off for Bleu score

### DIFF
--- a/bleu/bleu.py
+++ b/bleu/bleu.py
@@ -18,7 +18,7 @@ class Bleu:
         self._hypo_for_image = {}
         self.ref_for_image = {}
 
-    def compute_score(self, gts, res):
+    def compute_score(self, gts, res, verbose=1):
 
         assert(gts.keys() == res.keys())
         imgIds = gts.keys()
@@ -37,7 +37,7 @@ class Bleu:
             bleu_scorer += (hypo[0], ref)
 
         #score, scores = bleu_scorer.compute_score(option='shortest')
-        score, scores = bleu_scorer.compute_score(option='closest', verbose=1)
+        score, scores = bleu_scorer.compute_score(option='closest', verbose=verbose)
         #score, scores = bleu_scorer.compute_score(option='average', verbose=1)
 
         # return (bleu, bleu_info)


### PR DESCRIPTION
As it is now, the compute_score method from the Bleu class does not allow to choose the verbose option. I just added an optional parameter to the compute_method to allow to turn off the verbose.