### PR TITLE
Fix bugs in _score() method of Meteor class

### DIFF
--- a/meteor/meteor.py
+++ b/meteor/meteor.py
@@ -62,15 +62,15 @@ class Meteor:
         # SCORE ||| reference 1 words ||| reference n words ||| hypothesis words
         hypothesis_str = hypothesis_str.replace('|||','').replace('  ',' ')
         score_line = ' ||| '.join(('SCORE', ' ||| '.join(reference_list), hypothesis_str))
-        self.meteor_p.stdin.write('{}\n'.format(score_line))
-        stats = self.meteor_p.stdout.readline().strip()
+        self.meteor_p.stdin.write('{}\n'.format(score_line).encode())
+        stats = self.meteor_p.stdout.readline().decode().strip()
         eval_line = 'EVAL ||| {}'.format(stats)
         # EVAL ||| stats
-        self.meteor_p.stdin.write('{}\n'.format(eval_line))
-        score = float(self.meteor_p.stdout.readline().strip())
+        self.meteor_p.stdin.write('{}\n'.format(eval_line).encode())
+        score = float(self.meteor_p.stdout.readline().decode().strip())
         # bug fix: there are two values returned by the jar file, one average, and one all, so do it twice
         # thanks for Andrej for pointing this out
-        score = float(self.meteor_p.stdout.readline().strip())
+        score = float(self.meteor_p.stdout.readline().decode().strip())
         self.lock.release()
         return score
 

--- a/meteor/meteor.py
+++ b/meteor/meteor.py
@@ -68,9 +68,6 @@ class Meteor:
         # EVAL ||| stats
         self.meteor_p.stdin.write('{}\n'.format(eval_line).encode())
         score = float(self.meteor_p.stdout.readline().decode().strip())
-        # bug fix: there are two values returned by the jar file, one average, and one all, so do it twice
-        # thanks for Andrej for pointing this out
-        score = float(self.meteor_p.stdout.readline().decode().strip())
         self.lock.release()
         return score
 


### PR DESCRIPTION
I fixed 2 bugs in `_score()` function of Meteor class.

1. add `.encode()` and `.decode()` to `stdiin` and `stdout` functions, respectively.
2. remove overlapped line

for the 2nd bug fix, please see the discussion in https://github.com/jcjohnson/densecap/blob/master/eval/meteor_bridge.py#L42-L46