### PR TITLE
Enable verbosity control of PTBTokenizer

### DIFF
--- a/tokenizer/ptbtokenizer.py
+++ b/tokenizer/ptbtokenizer.py
@@ -23,7 +23,7 @@ PUNCTUATIONS = ["''", "'", "``", "`", "-LRB-", "-RRB-", "-LCB-", "-RCB-", \
 
 class PTBTokenizer:
     """Python wrapper of Stanford PTBTokenizer"""
-    def __init__(self, verbose):
+    def __init__(self, verbose=True):
         self.verbose = verbose
 
     def tokenize(self, captions_for_image):

--- a/tokenizer/ptbtokenizer.py
+++ b/tokenizer/ptbtokenizer.py
@@ -50,7 +50,7 @@ class PTBTokenizer:
         # tokenize sentence
         # ======================================================
         cmd.append(os.path.basename(tmp_file.name))
-        if verbose:
+        if self.verbose:
             p_tokenizer = subprocess.Popen(cmd, cwd=path_to_jar_dirname, \
                 stdout=subprocess.PIPE)
         else:

--- a/tokenizer/ptbtokenizer.py
+++ b/tokenizer/ptbtokenizer.py
@@ -23,6 +23,8 @@ PUNCTUATIONS = ["''", "'", "``", "`", "-LRB-", "-RRB-", "-LCB-", "-RCB-", \
 
 class PTBTokenizer:
     """Python wrapper of Stanford PTBTokenizer"""
+    def __init__(self, verbose):
+        self.verbose = verbose
 
     def tokenize(self, captions_for_image):
         cmd = ['java', '-cp', STANFORD_CORENLP_3_4_1_JAR, \
@@ -48,8 +50,12 @@ class PTBTokenizer:
         # tokenize sentence
         # ======================================================
         cmd.append(os.path.basename(tmp_file.name))
-        p_tokenizer = subprocess.Popen(cmd, cwd=path_to_jar_dirname, \
+        if verbose:
+            p_tokenizer = subprocess.Popen(cmd, cwd=path_to_jar_dirname, \
                 stdout=subprocess.PIPE)
+        else:
+            p_tokenizer = subprocess.Popen(cmd, cwd=path_to_jar_dirname, \
+                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
         token_lines = p_tokenizer.communicate(input=sentences.rstrip())[0]
         token_lines = token_lines.decode()
         lines = token_lines.split('\n')


### PR DESCRIPTION
PTBTokenizer logs tokenization details by default (ex. `PTBTokenizer tokenized 2 tokens at 33.87 tokens per second`).
This becomes noisy when you have run tokenization iteratively.
I redirect stderr to `subprocess.DEVNULL` to suppress this.