### PR TITLE
Change from http to https

### DIFF
--- a/spice/get_stanford_models.py
+++ b/spice/get_stanford_models.py
@@ -23,7 +23,7 @@ def get_stanford_models():
     # Only download file if file does not yet exist. Else: do nothing
     if not os.path.exists(jar_name):
         print('Downloading {} for SPICE ...'.format(JAR))
-        url = 'http://nlp.stanford.edu/software/{}.zip'.format(CORENLP)
+        url = 'https://nlp.stanford.edu/software/{}.zip'.format(CORENLP)
         zip_file, headers = urlretrieve(url, reporthook=print_progress)
         print()
         print('Extracting {} ...'.format(JAR))


### PR DESCRIPTION
Changed the URL for Stanford NLP from http to https. Without http produces a 404 error.